### PR TITLE
Fix issue #1: Remove trailing wrapper text after JSON blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2025-07-05
+
+### Fixed
+- Fixed issue where wrapper text following JSON blocks was not recognized (#1)
+  - Added dedicated `remove_trailing_wrapper_text/1` function in Layer 1
+  - Now properly removes trailing text after valid JSON structures
+  - Example: `[{"id": 1}]\n1 Volume(s) created` → `[{"id": 1}]`
+
 ## [0.1.2] - 2025-06-08
 
 ### Added

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule JsonRemedy.MixProject do
   use Mix.Project
 
-  @version "0.1.1"
+  @version "0.1.3"
   @source_url "https://github.com/nshkrdotcom/json_remedy"
 
   def project do


### PR DESCRIPTION
## Summary
- Fixes #1 by properly detecting and removing trailing wrapper text after JSON structures
- Adds comprehensive test coverage for the issue scenario
- Maintains backwards compatibility with existing functionality

## Problem
When JSON content was followed by trailing text (e.g., `[{...}]\n1 Volume(s) created`), the Layer 1 content cleaning was not removing the trailing wrapper text. This occurred because the `should_extract_from_prose?` function only checked for content that doesn't start with `{` or `[`.

## Solution
Implemented a dedicated `remove_trailing_wrapper_text/1` function that:
1. Detects when input starts with a JSON structure (`{` or `[`)
2. Uses the existing `find_balanced_end/3` function to find where the JSON ends
3. Checks if there's non-whitespace content after the JSON
4. Extracts only the JSON portion if trailing content exists

## Test Results
- New test case passes ✅
- All 452 existing tests continue to pass ✅
- No Dialyzer type warnings ✅
- Code formatted with `mix format` ✅

## Example
```elixir
# Before fix:
JsonRemedy.repair_to_string("[{\"id\": 1}]\n1 Volume(s) created")
# => {:error, "Could not repair JSON - all layers processed but validation failed"}

# After fix:
JsonRemedy.repair_to_string("[{\"id\": 1}]\n1 Volume(s) created")
# => {:ok, "[{\"id\":1}]"}
```

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>